### PR TITLE
Import readline on *nix

### DIFF
--- a/nustack/__main__.py
+++ b/nustack/__main__.py
@@ -34,6 +34,11 @@ def main():
             if input("Raise error? (y/n) ") in "yY":
                 raise
     else:
+        # import readline on *nix
+        try:
+            import readline
+        except ImportError:
+            pass
         print("Nustack v%s Interactive Prompt" % nustack.version)
         print("Running on Python %s" % sys.version)
         print("Enter your EOF character to exit.")


### PR DESCRIPTION
This adds readline support if it is available.
So you can do up and down for command history, use Emacs-like bindings such as Ctrl-E and Ctrl-A, etc.
